### PR TITLE
add "full-venv" argument to make shared libs optional

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -62,6 +62,7 @@ pipx install --help
 usage: pipx install [-h] [--spec SPEC] [--include-deps] [--verbose] [--force]
                     [--python PYTHON] [--system-site-packages]
                     [--index-url INDEX_URL] [--editable] [--pip-args PIP_ARGS]
+                    [--full-venv]
                     package
 
 The install command is the preferred way to globally install binaries
@@ -113,6 +114,9 @@ optional arguments:
   --editable, -e        Install a project in editable mode
   --pip-args PIP_ARGS   Arbitrary pip arguments to pass directly to pip
                         install/upgrade commands
+  --full-venv           Do not use the shared pipx venv for tools common
+                        across venvs. Instead, create a full venv for this
+                        package, including its own pip installation.
 
 ```
 
@@ -137,6 +141,7 @@ pipx run --help
 usage: pipx run [-h] [--no-cache] [--pypackages] [--spec SPEC] [--verbose]
                 [--python PYTHON] [--system-site-packages]
                 [--index-url INDEX_URL] [--editable] [--pip-args PIP_ARGS]
+                [--full-venv]
                 binary [binary_args [binary_args ...]]
 
 Download the latest version of a package to a temporary virtual environment,
@@ -174,6 +179,9 @@ optional arguments:
   --editable, -e        Install a project in editable mode
   --pip-args PIP_ARGS   Arbitrary pip arguments to pass directly to pip
                         install/upgrade commands
+  --full-venv           Do not use the shared pipx venv for tools common
+                        across venvs. Instead, create a full venv for this
+                        package, including its own pip installation.
 
 ```
 
@@ -352,7 +360,7 @@ pipx reinstall-all --help
 usage: pipx reinstall-all [-h] [--include-deps] [--system-site-packages]
                           [--index-url INDEX_URL] [--editable]
                           [--pip-args PIP_ARGS] [--skip SKIP [SKIP ...]]
-                          [--verbose]
+                          [--verbose] [--full-venv]
                           python
 
 Reinstalls all packages using a different version of Python.
@@ -381,6 +389,9 @@ optional arguments:
   --skip SKIP [SKIP ...]
                         skip these packages
   --verbose
+  --full-venv           Do not use the shared pipx venv for tools common
+                        across venvs. Instead, create a full venv for this
+                        package, including its own pip installation.
 
 ```
 

--- a/pipx/commands.py
+++ b/pipx/commands.py
@@ -47,6 +47,8 @@ def run(
     pypackages: bool,
     verbose: bool,
     use_cache: bool,
+    *,
+    full_venv: bool,
 ):
     """Installs venv to temporary dir (or reuses cache), then runs binary from
     package
@@ -92,7 +94,7 @@ def run(
 
     venv_dir = _get_temporary_venv_path(package_or_url, python, pip_args, venv_args)
 
-    venv = Venv(venv_dir)
+    venv = Venv(venv_dir, full_venv=full_venv)
     bin_path = venv.bin_path / binary
     _prepare_venv_cache(venv, bin_path, use_cache)
 
@@ -110,6 +112,7 @@ def run(
             pip_args,
             venv_args,
             verbose,
+            full_venv=full_venv,
         )
 
     if not use_cache:
@@ -126,8 +129,10 @@ def _download_and_run(
     pip_args: List[str],
     venv_args: List[str],
     verbose: bool,
+    *,
+    full_venv: bool,
 ):
-    venv = Venv(venv_dir, python=python, verbose=verbose)
+    venv = Venv(venv_dir, python=python, verbose=verbose, full_venv=full_venv)
     venv.create_venv(venv_args, pip_args)
     venv.install_package(package, pip_args)
     if not (venv.bin_path / binary).exists():
@@ -291,6 +296,7 @@ def install(
     *,
     force: bool,
     include_deps: bool,
+    full_venv: bool,
 ):
     try:
         exists = venv_dir.exists() and next(venv_dir.iterdir())
@@ -308,7 +314,7 @@ def install(
             )
             return
 
-    venv = Venv(venv_dir, python=python, verbose=verbose)
+    venv = Venv(venv_dir, python=python, verbose=verbose, full_venv=full_venv)
     try:
         venv.create_venv(venv_args, pip_args)
         venv.install_package(package_or_url, pip_args)
@@ -471,6 +477,7 @@ def reinstall_all(
     include_deps: bool,
     *,
     skip: List[str],
+    full_venv: bool,
 ):
     for venv_dir in venv_container.iter_venv_dirs():
         package = venv_dir.name
@@ -490,6 +497,7 @@ def reinstall_all(
             verbose,
             force=True,
             include_deps=include_deps,
+            full_venv=full_venv,
         )
 
 

--- a/pipx/main.py
+++ b/pipx/main.py
@@ -138,6 +138,7 @@ def run_pipx_command(args, binary_args: List[str]):
             args.spec if ("spec" in args and args.spec is not None) else args.binary
         )
         use_cache = not args.no_cache
+
         return commands.run(
             args.binary,
             package_or_url,
@@ -148,6 +149,7 @@ def run_pipx_command(args, binary_args: List[str]):
             args.pypackages,
             verbose,
             use_cache,
+            full_venv=args.full_venv,
         )
     elif args.command == "install":
         package_or_url = (
@@ -164,6 +166,7 @@ def run_pipx_command(args, binary_args: List[str]):
             verbose,
             force=args.force,
             include_deps=args.include_deps,
+            full_venv=args.full_venv,
         )
     elif args.command == "inject":
         if not args.include_binaries and args.include_deps:
@@ -216,6 +219,7 @@ def run_pipx_command(args, binary_args: List[str]):
             verbose,
             args.include_deps,
             skip=args.skip,
+            full_venv=args.full_venv,
         )
     elif args.command == "runpip":
         if not venv_dir:
@@ -255,6 +259,18 @@ def add_include_deps(parser):
     parser.add_argument(
         "--include-deps",
         help="Include binaries of dependent packages",
+        action="store_true",
+    )
+
+
+def add_full_venv_arg(parser):
+    parser.add_argument(
+        "--full-venv",
+        help=(
+            "Do not use the shared pipx venv for tools common across venvs. "
+            "Instead, create a full venv for this package, including its own "
+            "pip installation. "
+        ),
         action="store_true",
     )
 
@@ -304,6 +320,7 @@ def get_command_parser():
         ),
     )
     add_pip_venv_args(p)
+    add_full_venv_arg(p)
 
     p = subparsers.add_parser(
         "inject",
@@ -389,6 +406,7 @@ def get_command_parser():
     add_pip_venv_args(p)
     p.add_argument("--skip", nargs="+", default=[], help="skip these packages")
     p.add_argument("--verbose", action="store_true")
+    add_full_venv_arg(p)
 
     p = subparsers.add_parser(
         "list",
@@ -445,6 +463,7 @@ def get_command_parser():
         help="The Python version to run package's CLI binary with. Must be v3.3+.",
     )
     add_pip_venv_args(p)
+    add_full_venv_arg(p)
 
     p = subparsers.add_parser(
         "runpip",


### PR DESCRIPTION
@pfmoore This PR adds the command line option to use the full venv rather than the shared libs. However I am a little conflicted as to whether we should merge this change.

It makes the code and API more complicated, and in general I want to keep the complexity low by using sane defaults and avoiding supporting corner use-cases. I'm not really sure why someone would *not* want to use shared libs, and therefore it seems like a corner case that maybe we shouldn't support. What do you think?

In this PR:

* add flag `--full-venv` for install, reinstall-all, and run commands
* updated docs

Not in this PR:

* unit tests for `—full-venv` flag